### PR TITLE
Fix Security Vulnerability per CVE-2021-39336, Compatibility with WP 6.8.3

### DIFF
--- a/admin-applications.php
+++ b/admin-applications.php
@@ -196,6 +196,7 @@ function jobman_list_applications() {
 			<tr>
 				<th scope="col" id="cb" class="column-cb check-column"><input type="checkbox"></th>
 				<th scope="col"><?php _e( 'Application', 'jobman' ) ?></th>
+				<th scope="col"><?php _e( 'Date', 'jobman' ) ?></th>
 <?php
 	if( count( $fields ) > 0 ) {
 		foreach( $fields as $field ) {
@@ -215,6 +216,7 @@ function jobman_list_applications() {
 			<tr>
 				<th scope="col" class="column-cb check-column"><input type="checkbox"></th>
 				<th scope="col"><?php _e( 'Application', 'jobman' ) ?></th>
+				<th scope="col"><?php _e( 'Date', 'jobman' ) ?></th>
 <?php
 	if( count( $fields ) > 0 ) {
 		foreach( $fields as $field ) {
@@ -453,6 +455,7 @@ function jobman_list_applications() {
 				}
 				$name .= '<br/>';
 			}
+			$appdate = get_the_date('Y-m-d', $app);
 ?>
 			<tr>
 				<th scope="row" class="check-column"><input type="checkbox" name="application[]" value="<?php echo $app->ID ?>" /></th>
@@ -463,6 +466,7 @@ function jobman_list_applications() {
 				<?php echo $name ?>
 				<strong><a href="?page=jobman-list-applications&amp;appid=<?php echo $app->ID ?>"><?php _e( 'View Details', 'jobman' ) ?></a></strong>
 				</td>
+				<td><?php echo $appdate ?></td>
 <?php
 			if( count( $fields ) ) {
 				foreach( $fields as $id => $field ) {

--- a/admin-job-edit.php
+++ b/admin-job-edit.php
@@ -50,7 +50,7 @@ function jobman_updatedb_add(){
 // Which may include update or delete file attachment if included or requested
 // Or they can be of type checkbox or text
 // Then, remaining fields: jobman-displayenddate, jobman-icon, jobman-email,
-// jobman-highlighted, jobman_category
+// jobman-highlighted, jobman-categories
 function jobman_updatedb_edit(){
     global $current_user;
     $data = get_post( $_REQUEST['jobman-jobid'] );
@@ -171,7 +171,7 @@ function jobman_get_req_fields(){
     return $job_data;
 }
 
-// If item exists in the requesst, add it to the array and return
+// If item exists in the request, add it to the array and return
 function jobman_add_if_exists( $job_data, $key ){
     if( array_key_exists( $key, $_REQUEST) )
         $job_data[$key] = $_REQUEST[$key];
@@ -247,7 +247,7 @@ function jobman_sanitize_req_fields($job_data){
                         $job_data_san[$fid] = sanitize_text_field($job_data[$fid]);      
                         break;
                     case 'file':
-                        $job_data_san[$fid] = $job_data[$fid];      // Need to do.
+                        $job_data_san[$fid] = $job_data[$fid];      // Handled by jobman_job_field_upload
                         break;
                     case 'heading':
                         $job_data_san[$fid] = sanitize_text_field($job_data[$fid]);
@@ -302,14 +302,14 @@ function jobman_build_new_post(){
 // Handle requested file upload in new job or job edit
 // Returns ID for attachment post to store in metadata
 function jobman_job_field_upload ( $job_id, $field_index ){
-     $file_index = 'jobman-field-' . $field_index;
+    $file_index = 'jobman-field-' . $field_index;
     $overrides = array( 'action' => 'job_edit' );                   // Check for appropriate action for upload
     $upload = wp_handle_upload ( $_FILES[ $file_index ], $overrides );
     error_log('$upload -> ' . var_export($upload, true));
     if( ! array_key_exists ('error', $upload) ) {
         $filetype = wp_check_filetype( $upload['file'] );
         $attachment = array(
-                        'guid' => $upload['url'],
+                        'guid' => sanitize_url($upload['url']),
                         'post_title' => '',
                         'post_content' => '',
                         'post_status' => 'publish',

--- a/admin-job-edit.php
+++ b/admin-job-edit.php
@@ -2,7 +2,7 @@
 // Refactoring admin-jobs to support fixing security issues.
 // Need a new endpoint for job edit admin.
 // Was jobman_edit_job handlers
-// Modifying to use admin_post.php instead: https://developer.wordpress.org/reference/hooks/admin_post_action/
+// Modifying to use admin-post.php instead: https://developer.wordpress.org/reference/hooks/admin_post_action/
 // JM 11/28/25
 
 add_action( 'admin_post_job_edit', 'jobman_admin_job_edit' );
@@ -19,13 +19,199 @@ function jobman_admin_job_edit() {
 	    check_admin_referer( 'jobman-edit-job-' . $jobid );         // Confirm we're getting a valid call
         error_log ('Editing job #' . $jobid);
         if( $jobid == 'new' ){
-            jobman_updatedb_add();
+            jobman_updatedb_add();                                  // Add a new job
         } else {
-            jobman_updatedb_edit();
+            jobman_updatedb_edit();                                 // Edit an existing job
         }
 	}
 
-    jobman_jobedit_redirect();
+    jobman_jobedit_redirect();                                      // Return when done processing.
+}
+
+// Code from jobman_updatedb responsible for addding a new job
+function jobman_updatedb_add(){
+    if( 'new' == $_REQUEST['jobman-jobid'] ) {
+        $id = wp_insert_post( jobman_build_new_post() );
+        $options = get_option( 'jobman_options' );
+        $fields = $options['job_fields'];
+        if( count( $fields ) > 0 ) {
+            foreach( $fields as $fid => $field ) {
+                if($field['type'] != 'file' && ( ! array_key_exists( "jobman-field-$fid", $_REQUEST ) || '' == $_REQUEST["jobman-field-$fid"] ) )
+                    continue;
+
+                if( 'file' == $field['type'] && ! array_key_exists( "jobman-field-$fid", $_FILES ) )
+                    continue;
+
+                $data = '';
+                switch( $field['type'] ) {
+                    case 'file':
+                        if( is_uploaded_file( $_FILES["jobman-field-$fid"]['tmp_name'] ) ) {
+                            $upload = wp_upload_bits( $_FILES["jobman-field-$fid"]['name'], NULL, file_get_contents( $_FILES["jobman-field-$fid"]['tmp_name'] ) );
+                            $filetype = wp_check_filetype( $upload['file'] );
+                            if( ! $upload['error'] ) {
+                                $attachment = array(
+                                                'post_title' => '',
+                                                'post_content' => '',
+                                                'post_status' => 'publish',
+                                                'post_mime_type' => $filetype['type']
+                                            );
+                                $data = wp_insert_attachment( $attachment, $upload['file'], $id );
+                                $attach_data = wp_generate_attachment_metadata( $data, $upload['file'] );
+                                wp_update_attachment_metadata( $data, $attach_data );
+                            }
+                        }
+                        break;
+                    case 'checkbox':
+                        $data = implode( ', ', $_REQUEST["jobman-field-$fid"] );
+                        break;
+                    default:
+                        $data = sanitize_text_field( $_REQUEST["jobman-field-$fid"] );
+                }
+
+                add_post_meta( $id, "data$fid", $data, true );
+            }
+        }
+
+        add_post_meta( $id, 'displayenddate', stripslashes( $_REQUEST['jobman-displayenddate'] ), true );
+        add_post_meta( $id, 'iconid', $_REQUEST['jobman-icon'], true );
+        add_post_meta( $id, 'email', $_REQUEST['jobman-email'], true );
+
+        if( array_key_exists( 'jobman-highlighted', $_REQUEST ) && $_REQUEST['jobman-highlighted'] )
+            add_post_meta( $id, 'highlighted', 1, true );
+        else
+            add_post_meta( $id, 'highlighted', 0, true );
+
+        if( array_key_exists( 'jobman-categories', $_REQUEST ) )
+            wp_set_object_terms( $id, $_REQUEST['jobman-categories'], 'jobman_category', false );
+
+        if( $options['plugins']['gxs'] )
+            do_action( 'sm_rebuild' );
+    }
+}
+
+// Code from jobman_updatedb responsible for editing an existing job
+// Update fields like "jobman-field-X"
+// Which may include update or delete file attachment if included or requested
+// Or they can be of type checkbox or text
+// Then, remaining fields: jobman-displayenddate, jobman-icon, jobman-email,
+// jobman-highlighted, jobman_category
+function jobman_updatedb_edit(){
+    global $current_user;
+    $data = get_post( $_REQUEST['jobman-jobid'] );
+
+    // User is unable to edit this job
+    if( ! current_user_can( 'edit_others_posts' ) && $data->post_author != $current_user->ID )
+        return 4;
+
+    $job_data_raw = jobman_get_req_fields();
+    $job_data_san = jobman_sanitize_req_fields($job_data_raw);
+
+    $page['ID'] = $job_data_san['jobman-jobid'];
+    $id = wp_update_post( $page );
+    $options = get_option( 'jobman_options' );
+
+    // Process the sanitized submitted data
+    foreach( $job_data_san as $fid => $field ){
+        // Named ones
+        switch ($fid){
+            case 'jobman-jobid':
+                break;                                              // Don't change the id
+            case 'jobman-title':
+                $page['post_title'] = $field;
+                wp_update_post ( $page );
+                break;
+            case 'jobman-displaystartdate':
+                $page['post_date'] = $field;
+                wp_update_post ( $page );
+                break;
+            case 'jobman-displayenddate':
+                update_post_meta( $id, 'displayenddate', stripslashes( $field ) );
+                break;
+            case 'jobman-icon':
+                update_post_meta( $id, 'iconid', $field );
+                break;
+            case 'jobman-highlighed':
+                update_post_meta( $id, 'highlighted', $field );
+                break;
+            case 'jobman-categories':
+                wp_set_object_terms( $id, $field, 'jobman_category', false );
+                break;
+        // Editable ones like 'job-field-X'
+            default:
+                //error_log (var_export($options['job_fields']));
+                $field_num = substr( $fid, strlen('jobman-field-') );
+                if (is_numeric($field_num)) {
+                    $field_type = $options['job_fields'][$field_num]['type'];
+                    switch ( $field_type ){
+                        case 'file':                                // Should be either delete or upload    
+                            if ( $field == 'FILE_UPLOAD' ){
+                                $att_id = jobman_job_field_upload( $id, $field_num );   
+                                update_post_meta( $id, 'data' . $field_num, $att_id);  
+                            }                               
+                            break;
+                        case 'checkbox':
+                            $field_imp = implode( ', ', $field );   // Need to test this
+                            update_post_meta( $id, 'data' . $field_num, $field_imp );
+                            break;
+                        default:
+                            update_post_meta( $id, 'data' . $field_num, $field );
+                    }
+                } elseif ( substr($field_num, 0, 6) == 'delete' ) { // It's a delete attchment request
+                    $field_num = substr( $fid, strlen('jobman-field-delete-') );
+                    wp_delete_attachment( $job_data_san['jobman-field-current-' . $field_num] );
+                    update_post_meta( $id, 'data' . $field_num, '');
+                    error_log ('jobman_updatedb DELETE!');
+                } else {
+                    error_log ('jobman_updatedb_edit(): Not sure of type for ' . $fid . 
+                    ' I got this for field_num: ' . $field_num);
+                }
+        }
+    }
+
+	if( $options['plugins']['gxs'] )
+		do_action( 'sm_rebuild' );
+}
+
+// Return an associative array with the job fields included in the request
+function jobman_get_req_fields(){
+    $job_data = array();
+    $options = get_option( 'jobman_options' );
+    $fields = $options['job_fields'];
+
+    $job_data = jobman_add_if_exists( $job_data, 'jobman-jobid' );
+    $job_data = jobman_add_if_exists( $job_data, 'jobman-title' );
+    if( count( $fields ) > 0 ) {
+        foreach( $fields as $fid => $field ) {
+            if( $field['type'] == 'file' ){
+                if (is_uploaded_file( $_FILES["jobman-field-$fid"]['tmp_name'] ))
+                    $job_data['jobman-field-' . $fid] = "FILE_UPLOAD";
+            } else {
+                $job_data = jobman_add_if_exists( $job_data, 'jobman-field-' . $fid);
+            }
+            $job_data = jobman_add_if_exists( $job_data, 'jobman-field-delete-' . $fid);
+            $job_data = jobman_add_if_exists( $job_data, 'jobman-field-current-' . $fid);
+        }
+    }
+    $job_data = jobman_add_if_exists( $job_data, 'jobman-displaystartdate' );
+    $job_data = jobman_add_if_exists( $job_data, 'jobman-displayenddate' );
+    $job_data = jobman_add_if_exists( $job_data, 'jobman-icon' );
+    $job_data = jobman_add_if_exists( $job_data, 'jobman-highlighted' );
+    $job_data = jobman_add_if_exists( $job_data, 'jobman-categories' );
+
+    error_log ( 'jobman_get_req_fields(): ' . var_export($job_data, true) );
+    return $job_data;
+}
+
+// Sanitize request fields
+function jobman_sanitize_req_fields($job_data){
+    return $job_data;
+}
+
+// If item exists in the requesst, add it to the array and return
+function jobman_add_if_exists( $job_data, $key ){
+    if( array_key_exists( $key, $_REQUEST) )
+        $job_data[$key] = $_REQUEST[$key];
+    return $job_data;
 }
 
 // Build a blank post outline to use for creating new a job
@@ -55,132 +241,36 @@ function jobman_build_new_post(){
     return $page;
 }
 
-// Code from jobman_updatedb responsible for addding a new job
-function jobman_updatedb_add(){
-    if( 'new' == $_REQUEST['jobman-jobid'] ) {
-            $id = wp_insert_post( jobman_build_new_post() );
-            $options = get_option( 'jobman_options' );
-            $fields = $options['job_fields'];
-            if( count( $fields ) > 0 ) {
-                foreach( $fields as $fid => $field ) {
-                    if($field['type'] != 'file' && ( ! array_key_exists( "jobman-field-$fid", $_REQUEST ) || '' == $_REQUEST["jobman-field-$fid"] ) )
-                        continue;
-
-                    if( 'file' == $field['type'] && ! array_key_exists( "jobman-field-$fid", $_FILES ) )
-                        continue;
-
-                    $data = '';
-                    switch( $field['type'] ) {
-                        case 'file':
-                            if( is_uploaded_file( $_FILES["jobman-field-$fid"]['tmp_name'] ) ) {
-                                $upload = wp_upload_bits( $_FILES["jobman-field-$fid"]['name'], NULL, file_get_contents( $_FILES["jobman-field-$fid"]['tmp_name'] ) );
-                                $filetype = wp_check_filetype( $upload['file'] );
-                                if( ! $upload['error'] ) {
-                                    $attachment = array(
-                                                    'post_title' => '',
-                                                    'post_content' => '',
-                                                    'post_status' => 'publish',
-                                                    'post_mime_type' => $filetype['type']
-                                                );
-                                    $data = wp_insert_attachment( $attachment, $upload['file'], $id );
-                                    $attach_data = wp_generate_attachment_metadata( $data, $upload['file'] );
-                                    wp_update_attachment_metadata( $data, $attach_data );
-                                }
-                            }
-                            break;
-                        case 'checkbox':
-                            $data = implode( ', ', $_REQUEST["jobman-field-$fid"] );
-                            break;
-                        default:
-                            $data = $_REQUEST["jobman-field-$fid"];
-                    }
-
-                    add_post_meta( $id, "data$fid", $data, true );
-                }
-            }
-
-            add_post_meta( $id, 'displayenddate', stripslashes( $_REQUEST['jobman-displayenddate'] ), true );
-            add_post_meta( $id, 'iconid', $_REQUEST['jobman-icon'], true );
-            add_post_meta( $id, 'email', $_REQUEST['jobman-email'], true );
-
-            if( array_key_exists( 'jobman-highlighted', $_REQUEST ) && $_REQUEST['jobman-highlighted'] )
-                add_post_meta( $id, 'highlighted', 1, true );
-            else
-                add_post_meta( $id, 'highlighted', 0, true );
-        }
-}
-
-// Code from jobman_updatedb responsible for editing an existing job
-function jobman_updatedb_edit(){
-    global $current_user;
-    $data = get_post( $_REQUEST['jobman-jobid'] );
-
-    if( ! current_user_can( 'edit_others_posts' ) && $data->post_author != $current_user->ID )
-        return 4;
-
-    $page['ID'] = $_REQUEST['jobman-jobid'];
-    $id = wp_update_post( $page );
-    $options = get_option( 'jobman_options' );
-    $fields = $options['job_fields'];
-    if( count( $fields ) > 0 ) {
-        foreach( $fields as $fid => $field ) {
-            if( 'file' == $field['type'] && ! array_key_exists( "jobman-field-$fid", $_FILES ) && ! array_key_exists( "jobman-field-delete-$fid", $_REQUEST ) )
-                continue;
-
-            $data = '';
-            switch( $field['type'] ) {
-                case 'file':
-                    if( array_key_exists( "jobman-field-delete-$fid", $_REQUEST ) ) {
-                        wp_delete_attachment( $_REQUEST["jobman-field-current-$fid"] );
-                    }
-                    else if( is_uploaded_file( $_FILES["jobman-field-$fid"]['tmp_name'] ) ) {
-                        $upload = wp_upload_bits( $_FILES["jobman-field-$fid"]['name'], NULL, file_get_contents( $_FILES["jobman-field-$fid"]['tmp_name'] ) );
-                        if( ! $upload['error'] ) {
-                            // Delete the old attachment
-                            if( array_key_exists( "jobman-field-current-$fid", $_REQUEST ) )
-                                wp_delete_attachment( $_REQUEST["jobman-field-current-$fid"] );
-                            $filetype = wp_check_filetype( $upload['file'] );
-                            $attachment = array(
-                                            'post_title' => '',
-                                            'post_content' => '',
-                                            'post_status' => 'publish',
-                                            'post_mime_type' => $filetype['type']
-                                        );
-                            $data = wp_insert_attachment( $attachment, $upload['file'], $id );
-                            $attach_data = wp_generate_attachment_metadata( $data, $upload['file'] );
-                            wp_update_attachment_metadata( $data, $attach_data );
-                        }
-                        else {
-                            $data = get_post_meta( $id, "data$fid", true );
-                        }
-                    }
-                    else {
-                        $data = get_post_meta( $id, "data$fid", true );
-                    }
-                    break;
-                case 'checkbox':
-                    if( array_key_exists( "jobman-field-$fid", $_REQUEST ) && is_array( $_REQUEST["jobman-field-$fid"] ) )
-                        $data = implode( ', ', $_REQUEST["jobman-field-$fid"] );
-                    break;
-                default:
-                    if( array_key_exists( "jobman-field-$fid", $_REQUEST ) )
-                        $data = $_REQUEST["jobman-field-$fid"];
-            }
-
-            update_post_meta( $id, "data$fid", $data );
-        }
+// Handle requested file upload in new job or job edit
+// Returns ID for attachment post to store in metadata
+function jobman_job_field_upload ( $job_id, $field_index ){
+    //$upload = wp_upload_bits( $_FILES["jobman-field-$fid"]['name'], NULL, file_get_contents( $_FILES["jobman-field-$fid"]['tmp_name'] ) );
+    $file_index = 'jobman-field-' . $field_index;
+    $overrides = array( 'action' => 'job_edit' );                   // Check for appropriate action for upload
+    $upload = wp_handle_upload ( $_FILES[ $file_index ], $overrides );
+    error_log('$upload -> ' . var_export($upload, true));
+    if( ! array_key_exists ('error', $upload) ) {
+    //                         // Delete the old attachment
+    //                         if( array_key_exists( "jobman-field-current-$fid", $job_data_san ) )
+    //                             wp_delete_attachment( $job_data_san["jobman-field-current-$fid"] );
+        $filetype = wp_check_filetype( $upload['file'] );
+        $attachment = array(
+                        'guid' => $upload['url'],
+                        'post_title' => '',
+                        'post_content' => '',
+                        'post_status' => 'publish',
+                        'post_mime_type' => $filetype['type']
+                    );
+        $data = wp_insert_attachment( $attachment, $upload['file'], $job_id );
+        $attach_data = wp_generate_attachment_metadata( $data, $upload['file'] );
+        error_log('$attach_data -> ' . var_export($attach_data, true));
+        wp_update_attachment_metadata( $data, $attach_data );
+        return $data;
+    } else {                                                        // Upload error
+ //       $data = get_post_meta( $id, "data$fid", true );
+        error_log( 'jobman_job_field_upload() error: ' . var_export($upload['error'], true));
     }
 
-    update_post_meta( $id, 'displayenddate', stripslashes( $_REQUEST['jobman-displayenddate'] ) );
-    if( array_key_exists( 'jobman-icon', $_REQUEST) ){
-        update_post_meta( $id, 'iconid', $_REQUEST['jobman-icon'] );
-    }
-    update_post_meta( $id, 'email', $_REQUEST['jobman-email'] );
-
-    if( array_key_exists( 'jobman-highlighted', $_REQUEST ) && $_REQUEST['jobman-highlighted'] )
-        update_post_meta( $id, 'highlighted', 1 );
-    else
-        update_post_meta( $id, 'highlighted', 0 );
 }
 
 // Redirect helper: back to job list after a job edit

--- a/admin-job-edit.php
+++ b/admin-job-edit.php
@@ -1,0 +1,193 @@
+<?php
+// Refactoring admin-jobs to support fixing security issues.
+// Need a new endpoint for job edit admin.
+// Was jobman_edit_job handlers
+// Modifying to use admin_post.php instead: https://developer.wordpress.org/reference/hooks/admin_post_action/
+// JM 11/28/25
+
+add_action( 'admin_post_job_edit', 'jobman_admin_job_edit' );
+
+// Callback for admin-post.php when action "job_edit" is passed
+function jobman_admin_job_edit() {
+    // Handle request then generate response using echo or leaving PHP and using HTML
+    error_log ('job edit handler triggered...');
+    error_log ( var_export($_REQUEST, true) );
+
+	if( array_key_exists( 'jobmansubmit', $_REQUEST ) ) {
+	// Job form has been submitted. Update the database.
+        $jobid = $_REQUEST['jobman-jobid'];
+	    check_admin_referer( 'jobman-edit-job-' . $jobid );         // Confirm we're getting a valid call
+        error_log ('Editing job #' . $jobid);
+        if( $jobid == 'new' ){
+            jobman_updatedb_add();
+        } else {
+            jobman_updatedb_edit();
+        }
+	}
+
+    jobman_jobedit_redirect();
+}
+
+// Build a blank post outline to use for creating new a job
+function jobman_build_new_post(){
+	global $wpdb, $current_user;
+	$options = get_option( 'jobman_options' );
+
+	wp_get_current_user();
+
+	if( array_key_exists( 'jobman-displaystartdate', $_REQUEST ) && ! empty( $_REQUEST['jobman-displaystartdate'] ) )
+		$displaystartdate = date( 'Y-m-d H:i:s', strtotime( stripslashes( $_REQUEST['jobman-displaystartdate'] ) ) );
+	else
+		$displaystartdate = date( 'Y-m-d H:i:s' );
+
+	$page = array(
+				'comment_status' => 'closed',
+				'ping_status' => 'closed',
+				'post_status' => 'publish',
+				'post_content' => '',
+				'post_name' => strtolower( str_replace( ' ', '-', $_REQUEST['jobman-title'] ) ),
+				'post_title' => stripslashes( html_entity_decode( $_REQUEST['jobman-title'] ) ),
+				'post_type' => 'jobman_job',
+				'post_date' => $displaystartdate,
+				'post_date_gmt' => $displaystartdate,
+				'post_parent' => $options['main_page']);
+
+    return $page;
+}
+
+// Code from jobman_updatedb responsible for addding a new job
+function jobman_updatedb_add(){
+    if( 'new' == $_REQUEST['jobman-jobid'] ) {
+            $id = wp_insert_post( jobman_build_new_post() );
+            $options = get_option( 'jobman_options' );
+            $fields = $options['job_fields'];
+            if( count( $fields ) > 0 ) {
+                foreach( $fields as $fid => $field ) {
+                    if($field['type'] != 'file' && ( ! array_key_exists( "jobman-field-$fid", $_REQUEST ) || '' == $_REQUEST["jobman-field-$fid"] ) )
+                        continue;
+
+                    if( 'file' == $field['type'] && ! array_key_exists( "jobman-field-$fid", $_FILES ) )
+                        continue;
+
+                    $data = '';
+                    switch( $field['type'] ) {
+                        case 'file':
+                            if( is_uploaded_file( $_FILES["jobman-field-$fid"]['tmp_name'] ) ) {
+                                $upload = wp_upload_bits( $_FILES["jobman-field-$fid"]['name'], NULL, file_get_contents( $_FILES["jobman-field-$fid"]['tmp_name'] ) );
+                                $filetype = wp_check_filetype( $upload['file'] );
+                                if( ! $upload['error'] ) {
+                                    $attachment = array(
+                                                    'post_title' => '',
+                                                    'post_content' => '',
+                                                    'post_status' => 'publish',
+                                                    'post_mime_type' => $filetype['type']
+                                                );
+                                    $data = wp_insert_attachment( $attachment, $upload['file'], $id );
+                                    $attach_data = wp_generate_attachment_metadata( $data, $upload['file'] );
+                                    wp_update_attachment_metadata( $data, $attach_data );
+                                }
+                            }
+                            break;
+                        case 'checkbox':
+                            $data = implode( ', ', $_REQUEST["jobman-field-$fid"] );
+                            break;
+                        default:
+                            $data = $_REQUEST["jobman-field-$fid"];
+                    }
+
+                    add_post_meta( $id, "data$fid", $data, true );
+                }
+            }
+
+            add_post_meta( $id, 'displayenddate', stripslashes( $_REQUEST['jobman-displayenddate'] ), true );
+            add_post_meta( $id, 'iconid', $_REQUEST['jobman-icon'], true );
+            add_post_meta( $id, 'email', $_REQUEST['jobman-email'], true );
+
+            if( array_key_exists( 'jobman-highlighted', $_REQUEST ) && $_REQUEST['jobman-highlighted'] )
+                add_post_meta( $id, 'highlighted', 1, true );
+            else
+                add_post_meta( $id, 'highlighted', 0, true );
+        }
+}
+
+// Code from jobman_updatedb responsible for editing an existing job
+function jobman_updatedb_edit(){
+    global $current_user;
+    $data = get_post( $_REQUEST['jobman-jobid'] );
+
+    if( ! current_user_can( 'edit_others_posts' ) && $data->post_author != $current_user->ID )
+        return 4;
+
+    $page['ID'] = $_REQUEST['jobman-jobid'];
+    $id = wp_update_post( $page );
+    $options = get_option( 'jobman_options' );
+    $fields = $options['job_fields'];
+    if( count( $fields ) > 0 ) {
+        foreach( $fields as $fid => $field ) {
+            if( 'file' == $field['type'] && ! array_key_exists( "jobman-field-$fid", $_FILES ) && ! array_key_exists( "jobman-field-delete-$fid", $_REQUEST ) )
+                continue;
+
+            $data = '';
+            switch( $field['type'] ) {
+                case 'file':
+                    if( array_key_exists( "jobman-field-delete-$fid", $_REQUEST ) ) {
+                        wp_delete_attachment( $_REQUEST["jobman-field-current-$fid"] );
+                    }
+                    else if( is_uploaded_file( $_FILES["jobman-field-$fid"]['tmp_name'] ) ) {
+                        $upload = wp_upload_bits( $_FILES["jobman-field-$fid"]['name'], NULL, file_get_contents( $_FILES["jobman-field-$fid"]['tmp_name'] ) );
+                        if( ! $upload['error'] ) {
+                            // Delete the old attachment
+                            if( array_key_exists( "jobman-field-current-$fid", $_REQUEST ) )
+                                wp_delete_attachment( $_REQUEST["jobman-field-current-$fid"] );
+                            $filetype = wp_check_filetype( $upload['file'] );
+                            $attachment = array(
+                                            'post_title' => '',
+                                            'post_content' => '',
+                                            'post_status' => 'publish',
+                                            'post_mime_type' => $filetype['type']
+                                        );
+                            $data = wp_insert_attachment( $attachment, $upload['file'], $id );
+                            $attach_data = wp_generate_attachment_metadata( $data, $upload['file'] );
+                            wp_update_attachment_metadata( $data, $attach_data );
+                        }
+                        else {
+                            $data = get_post_meta( $id, "data$fid", true );
+                        }
+                    }
+                    else {
+                        $data = get_post_meta( $id, "data$fid", true );
+                    }
+                    break;
+                case 'checkbox':
+                    if( array_key_exists( "jobman-field-$fid", $_REQUEST ) && is_array( $_REQUEST["jobman-field-$fid"] ) )
+                        $data = implode( ', ', $_REQUEST["jobman-field-$fid"] );
+                    break;
+                default:
+                    if( array_key_exists( "jobman-field-$fid", $_REQUEST ) )
+                        $data = $_REQUEST["jobman-field-$fid"];
+            }
+
+            update_post_meta( $id, "data$fid", $data );
+        }
+    }
+
+    update_post_meta( $id, 'displayenddate', stripslashes( $_REQUEST['jobman-displayenddate'] ) );
+    if( array_key_exists( 'jobman-icon', $_REQUEST) ){
+        update_post_meta( $id, 'iconid', $_REQUEST['jobman-icon'] );
+    }
+    update_post_meta( $id, 'email', $_REQUEST['jobman-email'] );
+
+    if( array_key_exists( 'jobman-highlighted', $_REQUEST ) && $_REQUEST['jobman-highlighted'] )
+        update_post_meta( $id, 'highlighted', 1 );
+    else
+        update_post_meta( $id, 'highlighted', 0 );
+}
+
+// Redirect helper: back to job list after a job edit
+function jobman_jobedit_redirect() {
+    $redirect_url = admin_url('admin.php?page=jobman-list-jobs');
+    wp_safe_redirect( $redirect_url );
+    exit;
+}
+
+?>

--- a/admin-jobs-massedit.php
+++ b/admin-jobs-massedit.php
@@ -4,6 +4,133 @@
 // Was jobman_list_jobs handlers
 // JM 11/28/25
 
+add_action( 'admin_post_jobman_mass_edit_jobs', 'jobman_admin_mass_edit_jobs' );
 
+// Callback for admin-post.php when action "jmass_edit_jobs" is passed
+// Requested should be Delete, Archive or Unarchive
+function jobman_admin_mass_edit_jobs() {
+    // Handle request then generate response using echo or leaving PHP and using HTML
+    error_log ('Job mass edit handler triggered...');
+    error_log ( var_export($_REQUEST, true) );
+
+    if (array_key_exists('jobman-mass-edit-jobs', $_REQUEST)){
+        $req_action = sanitize_text_field($_REQUEST['jobman-mass-edit-jobs']);
+        switch ($req_action) {
+            case 'delete':
+                if( array_key_exists( 'jobman-delete-confirmed', $_REQUEST ) ) {
+                    check_admin_referer( 'jobman-mass-delete-jobs' );
+                    jobman_job_delete();
+			    } else {
+                    check_admin_referer( 'jobman-mass-edit-jobs' );
+                    $redirect_url = add_query_arg(
+                        'jobman-mass-edit-jobs', 'delete',
+                        admin_url('admin.php?page=jobman-list-jobs'));
+                    $redirect_url = add_query_arg(
+                        '_wpnonce', $_REQUEST['_wpnonce'],
+                        $redirect_url);
+                    wp_safe_redirect( $redirect_url );
+                    $redirect_url = add_query_arg(
+                        'job', $_REQUEST['job'],
+                        $redirect_url);
+                    wp_safe_redirect( $redirect_url );
+                    return;
+			    }
+                break;
+            case 'archive':
+                check_admin_referer( 'jobman-mass-edit-jobs' );
+			    jobman_job_archive();
+                break;
+            case 'unarchive':
+                check_admin_referer( 'jobman-mass-edit-jobs' );
+			    jobman_job_unarchive();
+                break;
+            default:
+                error_log( 'jobman_admin_mass_edit_jobs(): Unsure what to do with requested action ' . $req_action);
+        }
+    }
+
+    jobman_massedit_redirect();                                      // Return when done processing.
+}
+
+
+
+function jobman_job_delete() {
+	$options = get_option( 'jobman_options' );
+
+	$jobs = explode( ',', $_REQUEST['jobman-job-ids'] );
+
+	// Get the file fields
+	$file_fields = array();
+	foreach( $options['job_fields'] as $id => $field ) {
+		if( 'file' == $field['type'] )
+			$file_fields[] = $id;
+	}
+
+	foreach( $jobs as $job ) {
+		// Remove reference from applications
+		$apps = get_posts( 'post_type=jobman_app&numberposts=-1&meta_key=job&meta_value=' . $job );
+		if( ! empty( $apps ) ) {
+			foreach( $apps as $app ) {
+				delete_post_meta( $app->ID, 'job', $job );
+			}
+		}
+
+		$jobmeta = get_post_custom( $job );
+		$jobdata = array();
+		if( is_array( $jobmeta ) ) {
+			foreach( $jobmeta as $key => $value ) {
+				if( is_array( $value ) )
+					$jobdata[$key] = $value[0];
+				else
+					$jobdata[$key] = $value;
+			}
+		}
+
+		// Delete any files uploaded
+		foreach( $file_fields as $fid ) {
+			if( array_key_exists( "data$fid", $jobdata )  && '' != $jobdata["data$fid"] )
+				wp_delete_post( $jobdata["data$fid"] );
+		}
+		// Delete the job
+		wp_delete_post( $job );
+	}
+}
+
+function jobman_job_archive() {
+	$jobs = $_REQUEST['job'];
+
+	if( ! is_array( $jobs ) )
+		return;
+
+	$data = array( 'post_status' => 'draft' );
+	foreach( $jobs as $job ) {
+		$data['ID'] = $job;
+		wp_update_post( $data );
+	}
+}
+
+function jobman_job_unarchive() {
+	$jobs = $_REQUEST['job'];
+
+	if( ! is_array( $jobs ) )
+		return;
+
+	$data = array( 'post_status' => 'publish' );
+	foreach( $jobs as $job ) {
+		$data['ID'] = $job;
+		$data['post_date'] = date( 'Y-m-d H:i:s', strtotime( '-1 day' ) );
+		$data['post_date_gmt'] = date( 'Y-m-d H:i:s', strtotime( '-1 day' ) );
+		wp_update_post( $data );
+
+		update_post_meta( $job, 'displayenddate', '' );
+	}
+}
+
+// Redirect helper: back to job list after a mass edit
+function jobman_massedit_redirect() {
+    $redirect_url = admin_url('admin.php?page=jobman-list-jobs');
+    wp_safe_redirect( $redirect_url );
+    exit;
+}
 
 ?>

--- a/admin-jobs-massedit.php
+++ b/admin-jobs-massedit.php
@@ -1,0 +1,9 @@
+<?php
+// Refactoring admin-jobs to support fixing security issues.
+// Need a new endpoint for jobs mass edit from the job list admin.
+// Was jobman_list_jobs handlers
+// JM 11/28/25
+
+
+
+?>

--- a/admin-jobs-massedit.php
+++ b/admin-jobs-massedit.php
@@ -132,8 +132,8 @@ function jobman_massedit_delconf_redirect() {
 // Redirect helper: back to job list after a mass edit
 function jobman_massedit_redirect() {
     $redirect_url = admin_url('admin.php?page=jobman-list-jobs');
-    wp_safe_redirect( $redirect_url );
+	$redirect_url = add_query_arg('_wp_http_referer', admin_url('admin-post.php'), $redirect_url);
+	$redirect_url = add_query_arg('_wpnonce', $_REQUEST['_wpnonce'], $redirect_url);
+	wp_safe_redirect( $redirect_url );
     exit;
 }
-
-?>

--- a/admin-jobs-massedit.php
+++ b/admin-jobs-massedit.php
@@ -20,20 +20,9 @@ function jobman_admin_mass_edit_jobs() {
                 if( array_key_exists( 'jobman-delete-confirmed', $_REQUEST ) ) {
                     check_admin_referer( 'jobman-mass-delete-jobs' );
                     jobman_job_delete();
-			    } else {
+			    } else {											
                     check_admin_referer( 'jobman-mass-edit-jobs' );
-                    $redirect_url = add_query_arg(
-                        'jobman-mass-edit-jobs', 'delete',
-                        admin_url('admin.php?page=jobman-list-jobs'));
-                    $redirect_url = add_query_arg(
-                        '_wpnonce', $_REQUEST['_wpnonce'],
-                        $redirect_url);
-                    wp_safe_redirect( $redirect_url );
-                    $redirect_url = add_query_arg(
-                        'job', $_REQUEST['job'],
-                        $redirect_url);
-                    wp_safe_redirect( $redirect_url );
-                    return;
+					jobman_massedit_delconf_redirect();
 			    }
                 break;
             case 'archive':
@@ -51,8 +40,6 @@ function jobman_admin_mass_edit_jobs() {
 
     jobman_massedit_redirect();                                      // Return when done processing.
 }
-
-
 
 function jobman_job_delete() {
 	$options = get_option( 'jobman_options' );
@@ -124,6 +111,22 @@ function jobman_job_unarchive() {
 
 		update_post_meta( $job, 'displayenddate', '' );
 	}
+}
+
+// Redirect helper: delete confirm if delete requested but not yet confirmed
+function jobman_massedit_delconf_redirect() {
+	$redirect_url = add_query_arg(
+		'jobman-mass-edit-jobs', 'delete',
+		admin_url('admin.php?page=jobman-list-jobs'));
+	$redirect_url = add_query_arg(
+		'_wpnonce', $_REQUEST['_wpnonce'],
+		$redirect_url);
+	wp_safe_redirect( $redirect_url );
+	$redirect_url = add_query_arg(
+		'job', $_REQUEST['job'],
+		$redirect_url);
+	wp_safe_redirect( $redirect_url );
+	exit;
 }
 
 // Redirect helper: back to job list after a mass edit

--- a/admin-jobs.php
+++ b/admin-jobs.php
@@ -168,7 +168,7 @@ function jobman_list_jobs_data( $jobs, $showexpired = false ) {
 			elseif( ! $display )
 				$class = "expired";
 ?>
-			<tr class="<?php echo $class ?>">
+			<tr class="<?= $class ?>">
 				<th scope="row" class="check-column">
 <?php
 			if( current_user_can( 'edit_others_posts' ) || $job->post_author == $current_user->ID ) {
@@ -178,7 +178,12 @@ function jobman_list_jobs_data( $jobs, $showexpired = false ) {
 			}
 ?>
 				</th>
-				<td class="post-title page-title column-title"><strong><a href="?page=jobman-list-jobs&amp;jobman-jobid=<?php echo $job->ID ?>"><?php echo $job->post_title ?></a></strong>
+				<td class="post-title page-title column-title">
+					<strong>
+						<a href="?page=jobman-list-jobs&amp;jobman-jobid=<?php echo $job->ID ?>">
+							<?php echo $job->post_title ?>
+						</a>
+					</strong>
 				<div class="row-actions">
 <?php
 			if( current_user_can( 'edit_others_posts' ) || $job->post_author == $current_user->ID ) {
@@ -196,19 +201,19 @@ function jobman_list_jobs_data( $jobs, $showexpired = false ) {
 				if( $display ) {
 					$url = add_query_arg('jobman-mass-edit-jobs', 'archive', $url);
 ?>
-				| <a href="<?php echo $url; ?>"><?php _e( 'Archive X', 'jobman' ) ?></a>
+				| <a href="<?= $url; ?>"><?php _e( 'Archive', 'jobman' ) ?></a>
 <?php
 				}
 				else {
 					$url = add_query_arg('jobman-mass-edit-jobs', 'unarchive', $url);
 ?>
-				| <a href="<?php echo $url; ?>"><?php _e( 'Unarchive X', 'jobman' ) ?></a>
+				| <a href="<?= $url; ?>"><?php _e( 'Unarchive', 'jobman' ) ?></a>
 <?php
 				}
 			}
 ?>
 				</div></td>
-				<td><?php echo $catstring ?></td>
+				<td><?= $catstring ?></td>
 <?php
 			if( count( $fields ) ) {
 				foreach( $fields as $id => $field ) {
@@ -221,7 +226,7 @@ function jobman_list_jobs_data( $jobs, $showexpired = false ) {
 								$data = implode( ', ', $data );
 						}
 ?>
-				<td><?php echo $data ?></td>
+				<td><?= $data ?></td>
 <?php
 					}
 				}
@@ -232,9 +237,12 @@ function jobman_list_jobs_data( $jobs, $showexpired = false ) {
 			else if( ! $display )
 				$status = __( 'Expired', 'jobman' );
 ?>
-				<td><?php echo date( 'Y-m-d', strtotime( $job->post_date ) ) ?> - <?php echo ( '' == $displayenddate )?( __( 'End of Time', 'jobman' ) ):( $displayenddate ) ?><br/>
-				<?php echo $status ?></td>
-				<td><?php echo $applications ?></td>
+				<td>
+					<?php echo date( 'Y-m-d', strtotime( $job->post_date ) ) ?> - 
+					<?php echo ( '' == $displayenddate )?( __( 'End of Time', 'jobman' ) ):( $displayenddate ) ?>
+					<br/>
+				<?= $status ?></td>
+				<td><?= $applications ?></td>
 			</tr>
 <?php
 		}
@@ -311,16 +319,16 @@ function jobman_edit_job( $jobid ) {
 	?>" enctype="multipart/form-data" method="post">
 	<input type="hidden" name="action" value="job_edit"> 
 	<input type="hidden" name="jobmansubmit" value="1" />
-	<input type="hidden" name="jobman-jobid" value="<?php echo $jobid ?>" />
+	<input type="hidden" name="jobman-jobid" value="<?= $jobid ?>" />
 <?php
 	wp_nonce_field( "jobman-edit-job-$jobid");
 ?>
 	<div class="wrap">
-		<h2><?php echo $title ?></h2>
+		<h2><?= $title ?></h2>
 		<table id="jobman-job-edit" class="form-table">
 			<tr>
 				<th scope="row"><?php _e( 'Job ID', 'jobman' ) ?></th>
-				<td><?php echo $display_jobid ?></td>
+				<td><?= $display_jobid ?></td>
 				<td></td>
 			</tr>
 			<tr>
@@ -342,13 +350,17 @@ function jobman_edit_job( $jobid ) {
 ?>
 					<!-- Hidden control to send none when all unchecked -->
 					<input type="hidden" name="jobman-categories[]" value="" />
-					<input type="checkbox" name="jobman-categories[]" value="<?php echo $cat->slug ?>"<?php echo $checked ?> /> <?php echo $cat->name ?><br/>
+					<input type="checkbox" name="jobman-categories[]" value="<?php echo $cat->slug ?>"<?= $checked ?> /> <?php echo $cat->name ?><br/>
 <?php
 		}
 	}
 ?>
 				</div></td>
-				<td><span class="description"><?php _e( 'Categories that this job belongs to. It will be displayed in the job list for each category selected.', 'jobman' ) ?></span></td>
+				<td>
+					<span class="description">
+						<?php _e( 'Categories that this job belongs to. It will be displayed in the job list for each category selected.', 'jobman' ) ?>
+					</span>
+				</td>
 			</tr>
 			<tr>
 				<th scope="row"><?php _e( 'Icon', 'jobman' ) ?></th>
@@ -363,7 +375,8 @@ function jobman_edit_job( $jobid ) {
 
 			$post = get_post( $icon );
 ?>
-					<input type="radio" name="jobman-icon" value="<?php echo $icon ?>"<?php echo $checked ?> /> <img src="<?php echo wp_get_attachment_url( $icon ) ?>" /> <?php echo $post->post_title ?><br/>
+					<input type="radio" name="jobman-icon" value="<?= $icon ?>"<?= $checked ?> /> 
+					<img src="<?php echo wp_get_attachment_url( $icon ) ?>" /> <?php echo $post->post_title ?><br/>
 <?php
 		}
 	}
@@ -373,13 +386,16 @@ function jobman_edit_job( $jobid ) {
 	else
 		$checked = '';
 ?>
-					<input type="radio" name="jobman-icon"<?php echo $checked ?> value="" /> <?php _e( 'No Icon', 'jobman' ) ?><br/>
+					<input type="radio" name="jobman-icon"<?= $checked ?> value="" /> <?php _e( 'No Icon', 'jobman' ) ?><br/>
 				</div></td>
 				<td><span class="description"><?php _e( 'Icon to display for this job in the Job List', 'jobman' ) ?></span></td>
 			</tr>
 			<tr>
 				<th scope="row"><?php _e( 'Title', 'jobman' ) ?></th>
-				<td><input class="regular-text code" type="text" name="jobman-title" value="<?php echo ( isset( $job->post_title ) )?( $job->post_title ):( '' ) ?>" /></td>
+				<td>
+					<input class="regular-text code" type="text" name="jobman-title" 
+					value="<?php echo ( isset( $job->post_title ) )?( $job->post_title ):( '' ) ?>" />
+				</td>
 				<td></td>
 			</tr>
 <?php
@@ -534,18 +550,44 @@ function jobman_edit_job( $jobid ) {
 ?>
 			<tr>
 				<th scope="row"><?php _e( 'Display Start Date', 'jobman' ) ?></th>
-				<td><input class="datepicker" type="text" name="jobman-displaystartdate" value="<?php echo ( 'new' != $jobid )?( date( 'Y-m-d', strtotime( $job->post_date ) ) ):( '' ) ?>" /></td>
-				<td><span class="description"><?php _e( 'The date this job should start being displayed on the site. To start displaying immediately, leave blank.', 'jobman' ) ?></span></td>
+				<td>
+					<input class="datepicker" type="text" name="jobman-displaystartdate" 
+						value="<?php echo ( 'new' != $jobid )?( date( 'Y-m-d', strtotime( $job->post_date ) ) ):( '' ) ?>" />
+				</td>
+				<td>
+					<span class="description">
+						<?php _e( 'The date this job should start being displayed on the site. To start displaying 
+						immediately, leave blank.', 'jobman' ) ?>
+					</span>
+				</td>
 			</tr>
 			<tr>
 				<th scope="row"><?php _e( 'Display End Date', 'jobman' ) ?></th>
-				<td><input class="datepicker" type="text" name="jobman-displayenddate" value="<?php echo ( array_key_exists( 'displayenddate', $jobdata ) )?( $jobdata['displayenddate'] ):( '' ) ?>" /></td>
-				<td><span class="description"><?php _e( 'The date this job should stop being displayed on the site. To display indefinitely, leave blank.', 'jobman' ) ?></span></td>
+				<td>
+					<input class="datepicker" type="text" name="jobman-displayenddate" 
+						value="<?php echo ( array_key_exists( 'displayenddate', $jobdata ) )?( $jobdata['displayenddate'] ):( '' ) ?>" />
+				</td>
+				<td>
+					<span class="description">
+						<?php _e( 'The date this job should stop being displayed on the site. To display indefinitely, 
+						leave blank.', 'jobman' ) ?>
+					</span>
+				</td>
 			</tr>
 			<tr>
-				<th scope="row"><?php _e( 'Application Email', 'jobman' ) ?></th>
-				<td><input class="regular-text" type="text" name="jobman-email" value="<?php echo ( array_key_exists( 'email', $jobdata ) )?( $jobdata['email'] ):( '' ) ?>" /></td>
-				<td><span class="description"><?php _e( 'The email address to notify when an application is submitted for this job. For default behaviour (category email or global email), leave blank.', 'jobman' ) ?></span></td>
+				<th scope="row">
+					<?php _e( 'Application Email', 'jobman' ) ?>
+				</th>
+				<td>
+					<input class="regular-text" type="text" name="jobman-email" 
+						value="<?php echo ( array_key_exists( 'email', $jobdata ) )?( $jobdata['email'] ):( '' ) ?>" />
+				</td>
+				<td>
+					<span class="description">
+						<?php _e( 'The email address to notify when an application is submitted for this job. For 
+						default behaviour (category email or global email), leave blank.', 'jobman' ) ?>
+					</span>
+				</td>
 			</tr>
 <?php
 	$checked = '';
@@ -557,12 +599,16 @@ function jobman_edit_job( $jobid ) {
 				<td>
 					<!-- Hidden control to send a '0' when unchecked -->
 					<input type="hidden" name="jobman-highlighted" value="0">				
-					<input type="checkbox" name="jobman-highlighted" value="1" <?php echo $checked ?>/>
+					<input type="checkbox" name="jobman-highlighted" value="1" <?= $checked ?>/>
 				</td>
-				<td><span class="description"><?php _e( 'Mark this job as highlighted? For the behaviour of highlighted jobs, see the Display Settings admin page.', 'jobman' ) ?></span></td>
+				<td>
+					<span class="description"><?php _e( 'Mark this job as highlighted? For the behaviour of highlighted
+					 jobs, see the Display Settings admin page.', 'jobman' ) ?>
+					</span>
+				</td>
 			</tr>
 		</table>
-		<p class="submit"><input type="submit" name="submit"  class="button-primary" value="<?php echo $submit ?>" /></p>
+		<p class="submit"><input type="submit" name="submit"  class="button-primary" value="<?= $submit ?>" /></p>
 	</div>
 	</form>
 <?php

--- a/admin-jobs.php
+++ b/admin-jobs.php
@@ -288,14 +288,6 @@ function jobman_edit_job( $jobid ) {
 		// Job form has been submitted. Update the database.
 		error_log( 'Job Manager: Call to admin.php with jobmansubmit set.  Please update to use admin-post.php.');
 		check_admin_referer( 'jobman-edit-job-$jobid' );
-		$error = false; //jobman_updatedb();
-
-		if( $error )
-			return $error;
-		else if ( 'new' == $jobid )
-			return 2;
-		else
-			return 3;
 	}
 
 	if( 'new' == $jobid ) {
@@ -340,16 +332,11 @@ function jobman_edit_job( $jobid ) {
 			wp_tiny_mce( false, array( 'editor_selector' => 'jobman-editor' ) );
 	}
 ?>
-	<form action="<?php 
-	//	echo admin_url('admin.php?page=jobman-list-jobs') 
-		echo admin_url('admin-post.php');
-	?>" enctype="multipart/form-data" method="post">
+	<form action="<?php echo admin_url('admin-post.php'); ?>" enctype="multipart/form-data" method="post">
 	<input type="hidden" name="action" value="job_edit"> 
 	<input type="hidden" name="jobmansubmit" value="1" />
 	<input type="hidden" name="jobman-jobid" value="<?= $jobid ?>" />
-<?php
-	wp_nonce_field( "jobman-edit-job-$jobid");
-?>
+	<?php wp_nonce_field( "jobman-edit-job-$jobid"); ?>
 	<div class="wrap">
 		<h2><?= $title ?></h2>
 		<table id="jobman-job-edit" class="form-table">

--- a/admin-jobs.php
+++ b/admin-jobs.php
@@ -336,6 +336,8 @@ function jobman_edit_job( $jobid ) {
 				}
 			}
 ?>
+					<!-- Hidden control to send none when all unchecked -->
+					<input type="hidden" name="jobman-categories[]" value="" />
 					<input type="checkbox" name="jobman-categories[]" value="<?php echo $cat->slug ?>"<?php echo $checked ?> /> <?php echo $cat->name ?><br/>
 <?php
 		}
@@ -423,7 +425,7 @@ function jobman_edit_job( $jobid ) {
 					echo '</td>';
 					echo "<td><span class='description'>{$field['description']}</span></td></tr>";
 					break;
-				case 'checkbox':
+				case 'checkbox':									// The intent was to have an array of checkboxes I think?
 					if( '' != $field['label'] )
 						echo "<th scope='row'>{$field['label']}</th><td>";
 					else
@@ -442,6 +444,10 @@ function jobman_edit_job( $jobid ) {
 						$checked = '';
 						if( in_array( $value, $data ) )
 							$checked = ' checked="checked"';
+						?> 
+							<!-- Hidden input to send blank string when all are unchecked -->
+							<input type="hidden" name="jobman-field-<?= $id ?>[]" value="" />				
+						<?php
 						echo "<input type='checkbox' name='jobman-field-{$id}[]' value='$value'$checked /> {$display_values[$key]}<br/>";
 					}
 					echo '</td>';
@@ -544,7 +550,11 @@ function jobman_edit_job( $jobid ) {
 ?>
 			<tr>
 				<th scope="row"><?php _e( 'Highlighted?', 'jobman' ) ?></th>
-				<td><input type="checkbox" name="jobman-highlighted" value="1" <?php echo $checked ?>/></td>
+				<td>
+					<!-- Hidden control to send a '0' when unchecked -->
+					<input type="hidden" name="jobman-highlighted" value="0">				
+					<input type="checkbox" name="jobman-highlighted" value="1" <?php echo $checked ?>/>
+				</td>
 				<td><span class="description"><?php _e( 'Mark this job as highlighted? For the behaviour of highlighted jobs, see the Display Settings admin page.', 'jobman' ) ?></span></td>
 			</tr>
 		</table>

--- a/admin-jobs.php
+++ b/admin-jobs.php
@@ -555,39 +555,6 @@ function jobman_edit_job( $jobid ) {
 	return 1;
 }
 
-function jobman_updatedb() {
-	global $wpdb, $current_user;
-	$options = get_option( 'jobman_options' );
-
-	wp_get_current_user();
-
-	if( array_key_exists( 'jobman-displaystartdate', $_REQUEST ) && ! empty( $_REQUEST['jobman-displaystartdate'] ) )
-		$displaystartdate = date( 'Y-m-d H:i:s', strtotime( stripslashes( $_REQUEST['jobman-displaystartdate'] ) ) );
-	else
-		$displaystartdate = date( 'Y-m-d H:i:s' );
-
-	$page = array(
-				'comment_status' => 'closed',
-				'ping_status' => 'closed',
-				'post_status' => 'publish',
-				'post_content' => '',
-				'post_name' => strtolower( str_replace( ' ', '-', $_REQUEST['jobman-title'] ) ),
-				'post_title' => stripslashes( html_entity_decode( $_REQUEST['jobman-title'] ) ),
-				'post_type' => 'jobman_job',
-				'post_date' => $displaystartdate,
-				'post_date_gmt' => $displaystartdate,
-				'post_parent' => $options['main_page']);
-
-	if( 'new' == $_REQUEST['jobman-jobid'] ) {
-		error_log( 'Job Manager: Call to jobman_updatedb() to create new job.  Please use jobman_updatedb_add() instead.');
-	}
-	else {
-		error_log( 'Job Manager: Call to jobman_updatedb() to edit existing job.  Please use jobman_updatedb_edit() instead.');
-	}
-
-	return 0;
-}
-
 function jobman_job_delete_confirm() {
 ?>
 	<div class="wrap">

--- a/admin-jobs.php
+++ b/admin-jobs.php
@@ -506,8 +506,8 @@ function jobman_edit_job( $jobid ) {
 					echo '</table>';
 					echo "<h3>{$field['label']}</h3>";
 					echo "<table>";
-					$tablecount++;
-					$totalrowcount--;
+//					$tablecount++;
+//					$totalrowcount--;
 					$rowcount = 0;
 					break;
 				case 'html':
@@ -584,12 +584,6 @@ function jobman_updatedb() {
 	else {
 		error_log( 'Job Manager: Call to jobman_updatedb() to edit existing job.  Please use jobman_updatedb_edit() instead.');
 	}
-
-	if( array_key_exists( 'jobman-categories', $_REQUEST ) )
-		wp_set_object_terms( $id, $_REQUEST['jobman-categories'], 'jobman_category', false );
-
-	if( $options['plugins']['gxs'] )
-		do_action( 'sm_rebuild' );
 
 	return 0;
 }

--- a/admin-settings.php
+++ b/admin-settings.php
@@ -128,6 +128,10 @@ function jobman_print_settings_box() {
 				<th scope="row"><?php _e( 'Default email', 'jobman' ) ?></th>
 				<td colspan="2"><input class="regular-text code" type="text" name="default-email" value="<?php echo $options['default_email'] ?>" /></td>
 			</tr>
+			<tr>
+				<th scope="row"><?php _e( 'reCaptcha v2 Site Key', 'jobman' ) ?></th>
+				<td colspan="2"><input class="regular-text code" type="text" name="recaptcha-key" value="<?php echo $options['recaptcha_key'] ?>" /></td>
+			</tr>
 		</table>
 		
 		<p class="submit"><input type="submit" name="submit"  class="button-primary" value="<?php _e( 'Update Settings', 'jobman' ) ?>" /></p>
@@ -592,6 +596,7 @@ function jobman_conf_updatedb() {
 	$options = get_option( 'jobman_options' );
 	
 	$options['default_email'] = $_REQUEST['default-email'];
+	$options['recaptcha_key'] = $_REQUEST['recaptcha-key'];
 
 	if( array_key_exists( 'multi-applications', $_REQUEST ) && $_REQUEST['multi-applications'] )
 		$options['multi_applications'] = 1;

--- a/admin.php
+++ b/admin.php
@@ -8,6 +8,8 @@ require_once( JOBMAN_DIR . '/admin-frontend-settings.php' );
 require_once( JOBMAN_DIR . '/admin-jobs-settings.php' );
 // Job management
 require_once( JOBMAN_DIR . '/admin-jobs.php' );
+require_once( JOBMAN_DIR . '/admin-job-edit.php' );
+require_once( JOBMAN_DIR . '/admin-jobs-massedit.php' );
 // Application form setup
 require_once( JOBMAN_DIR . '/admin-application-form.php' );
 // Applications

--- a/admin.php
+++ b/admin.php
@@ -46,11 +46,11 @@ function jobman_admin_setup() {
 }
 
 function jobman_plugin_row_meta( $links, $file ) {
-	if( JOBMAN_BASENAME == $file && ! get_option( 'smb_consulting' ) ) {
-		$links[] = '<a href="http://www.wp-jobmanager.com/">' . __( 'Visit plugin site', 'jobman' ) . '</a>';
-	}
+// 	if( JOBMAN_BASENAME == $file && ! get_option( 'smb_consulting' ) ) {
+// 		$links[] = '<a href="https://wordpress.org/plugins/job-manager/">' . __( 'Visit plugin site', 'jobman' ) . '</a>';
+// 	}
 
-	return $links;
+ 	return $links;
 }
 
 function jobman_admin_print_styles() {

--- a/css/display.css
+++ b/css/display.css
@@ -50,7 +50,7 @@ table.jobs-table th, table.job-table th {
 }
 
 table.job-table th {
-	width: 100px;
+	width: 25%;
 }
 
 table.highlighted {

--- a/frontend-application.php
+++ b/frontend-application.php
@@ -255,7 +255,10 @@ function jobman_display_apply_generated( $foundjob = false, $job = NULL, $cat = 
 		ob_end_clean();
 	}
 
-	$content .= '<tr><td colspan="2" class="submit"><input type="submit" name="submit"  class="button-primary" value="' . __( 'Submit Your Application', 'jobman' ) . '" /></td></tr>';
+	// Add recaptcha v2 JM 10/28/21
+	$content .= '<tr><td colspan = "2"><div class="g-recaptcha" data-sitekey="' . $options['recaptcha_key'] . '"></div></td></tr>';
+	$content .= '<tr><td colspan="2" class="submit"><input type="submit" name="submit"  class="button-primary gform_button button" ';
+	$content .= 'value="' . __( 'Submit Your Application', 'jobman' ) . '" /></td></tr>';
 	$content .= '</table>';
 
 	return $content;

--- a/hooks.php
+++ b/hooks.php
@@ -44,10 +44,15 @@ add_action( 'do_feed_jobman', 'jobman_rss_feed', 1, 1 );
 //
 // Widgets
 //
-add_action( 'widgets_init', create_function( '', 'return register_widget("JobmanLatestJobsWidget");' ) );
-add_action( 'widgets_init', create_function( '', 'return register_widget("JobmanCategoriesWidget");' ) );
-add_action( 'widgets_init', create_function( '', 'return register_widget("JobmanHighlightedJobsWidget");' ) );
-add_action( 'widgets_init', create_function( '', 'return register_widget("JobmanJobsWidget");' ) );
+add_action( 'widgets_init', 'jobman_widgets_init');
+
+function jobman_widgets_init() {
+	register_widget('JobmanLatestJobsWidget');
+	register_widget('JobmanCategoriesWidget');
+	register_widget('JobmanHighlightedJobsWidget');
+	register_widget('JobmanJobsWidget');
+	
+}
 
 //
 // Admin Hooks

--- a/job-manager.php
+++ b/job-manager.php
@@ -3,8 +3,8 @@
 Plugin Name: Job Manager
 Plugin URI: http://wp-jobmanager.com/
 Description: A job listing and job application management plugin for WordPress.
-Version: 0.7.25
-Author: Tom Townsend
+Version: 0.8.3
+Author: Tom Townsend, Modified by Jason Merrick
 Author URI: http://www.linkedin.com/in/thomastownsend
 Text Domain: jobman
 Tags: application, applicant tracking, ats, board, candidate, candidates, career, company, current opportunities, direct hire, employee, employer, employees, employment, freelance,
@@ -33,7 +33,7 @@ placement, position, positions, recruiter, recruiting, recruitment, talent
 */
 
 // Version
-define( 'JOBMAN_VERSION', '0.7.25' );
+define( 'JOBMAN_VERSION', '0.8.3' );
 define( 'JOBMAN_DB_VERSION', 19 );
 
 // Define the URL to the plugin folder
@@ -119,6 +119,9 @@ function jobman_nag_ignore() {
 // Load Jobman
 //
 
+// Call jobman_activate so that shortcodes are available for loading
+add_action('init', 'jobman_activate');
+
 // Jobman global functions
 require_once( JOBMAN_DIR . '/functions.php' );
 
@@ -142,6 +145,9 @@ require_once( JOBMAN_DIR . '/widgets.php' );
 
 // Add hooks at the end
 require_once( JOBMAN_DIR . '/hooks.php' );
+
+// Add support for shotcodes in regular pages and posts
+require_once( JOBMAN_DIR . '/shortcodes.php');
 
 // If the user is after a CSV export, give it to them
 if( array_key_exists( 'jobman-mass-edit', $_REQUEST ) && 'export-csv' == $_REQUEST['jobman-mass-edit'] )

--- a/job-manager.php
+++ b/job-manager.php
@@ -83,25 +83,20 @@ if( is_array( $jobman_options ) && array_key_exists( 'fields', $jobman_options )
 add_action('admin_notices', 'jobman_admin_notice');
 
 function jobman_admin_notice() {
-if ( current_user_can( 'install_plugins' ) )
-   {
-	global $current_user ;
-        $user_id = $current_user->ID;
-        /* Check that the user hasn't already clicked to ignore the message */
-	if ( ! get_user_meta($user_id, 'jobman_ignore_notice') ) {
-        echo '<div class="updated"><p>';   
-        printf(__('Thanks! We hope you enjoy using <a href="http://www.wp-jobmanager.com/go/jobman/" 
-
-target="_blank"><b>Job Manager</b></a>.Please consider<a href="http://www.wp-jobmanager.com/go/rating/" 
-
-target="_blank"><b>Rating</b></a> us. You can also check-out and contribute to our<a href="http://www.wp-jobmanager.com/go/kb/"
-
-target="_blank"><b>Knowledge Base</b></a>. Thanks for your help and rating. | <a 
-
-href="%1$s">Hide Notice</a>'), '?jobman_nag_ignore=0');
-        echo "</p></div>";
+	if ( current_user_can( 'install_plugins' ) ){
+		global $current_user ;
+		$user_id = $current_user->ID;
+		/* Check that the user hasn't already clicked to ignore the message */
+		if ( ! get_user_meta($user_id, 'jobman_ignore_notice') ) {
+			?>
+			<div class="updated"><p>
+			Thanks! We hope you enjoy using <a href="https://github.com/thomastownsend/job-manager" target="_blank"><b>Job Manager</b></a>.
+			Please check-out and contribute to our <a href="https://wordpress.org/support/plugin/job-manager/" target="_blank"><b>Support Forum</b></a>.
+			Thanks for your help! | <a href="<?php printf('%1$s', '?jobman_nag_ignore=0'); ?>">Hide Notice</a>
+			</p></div>
+			<?php
+		}
 	}
-    }
 }
 
 add_action('admin_init', 'jobman_nag_ignore');
@@ -112,6 +107,9 @@ function jobman_nag_ignore() {
         /* If user clicks to ignore the notice, add that to their user meta */
         if ( isset($_GET['jobman_nag_ignore']) && '0' == $_GET['jobman_nag_ignore'] ) {
              add_user_meta($user_id, 'jobman_ignore_notice', 'true', true);
+	 
+        // Always redirect after processing
+        wp_safe_redirect( admin_url( 'admin.php?page=jobman-conf' ) );
 	}
 }
     

--- a/job-manager.php
+++ b/job-manager.php
@@ -1,7 +1,7 @@
 <?php //encoding: utf-8
 /*
 Plugin Name: Job Manager
-Plugin URI: http://wp-jobmanager.com/
+Plugin URI: https://wordpress.org/plugins/job-manager/
 Description: A job listing and job application management plugin for WordPress.
 Version: 0.8.3
 Author: Tom Townsend, Modified by Jason Merrick

--- a/js/display.js
+++ b/js/display.js
@@ -1,6 +1,7 @@
 function jobman_apply_filter() {
 	var ii, field, value, type;
 	var empty = new Array();
+	var recaptcha_response = grecaptcha.getResponse();
 	for( ii = 0; ii < jobman_mandatory_ids.length; ii++ ) {
 		field = jQuery('[name^="jobman-field-' + jobman_mandatory_ids[ii] + '"]');
 		
@@ -33,8 +34,12 @@ function jobman_apply_filter() {
 				empty.push( jobman_mandatory_labels[ii] );
 			}
 		}
-	}
 	
+	}
+	if (recaptcha_response.length === 0){
+		empty.push( 'I\'m not a robot checkbox' );
+	}
+		
 	if( empty.length > 0 ) {
 		var error = jobman_strings['apply_submit_mandatory_warning'] + ":\n";
 		for( ii = 0; ii < empty.length; ii++ ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Job Manager ===
 Contributors: SMB-dev, gobblelogic, jmdevnet
 Donate link: http://www.wp-jobmanager.com/donate/
-Plugin URI: http://www.wp-jobmanager.com
+Plugin URI: https://wordpress.org/plugins/job-manager/
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: application, applicant tracking, ats, board, candidate, candidates, career, company, current opportunities, direct hire, employee, employer, employees, employment, freelance,
@@ -58,7 +58,7 @@ the interview process, Job Manager supports all the features you need to manage 
 
 = Links =
 
-* [Plugin Homepage](http://www.wp-jobmanager.com/)
+* [Plugin Homepage](https://wordpress.org/plugins/job-manager/)
 * [Support Forum](http://wordpress.org/tags/job-manager?forum_id=10)
 * [Report Bugs and Request Enhancments](https://bitbucket.org/jobmanager_hp/job-manager/issues)
 * [Knowledge Base - Documentation](http://www.wp-jobmanager/documentation)

--- a/readme.txt
+++ b/readme.txt
@@ -8,8 +8,8 @@ Tags: application, applicant tracking, ats, board, candidate, candidates, career
       hiring, hire, interview, interviews, job, jobs, job board, job list, job lists ,job listing, job manager, job management, job role, job search,  list, listing, manager, opportunities,
       placement, position, positions, recruiter, recruiting, recruitment, talent
 Requires at least: 2.9
-Tested up to: 4.3
-Stable tag: 7.2.5
+Tested up to: 6.8.3
+Stable tag: 8.3.0
 
 A job listing and job application management plugin for WordPress.
 
@@ -201,6 +201,10 @@ Notice the version number in brackets. This is the version series that the trans
 Print Icon by [Piotr Kwiatkowski](http://www.piotrkwiatkowski.co.uk), under a [CC BY-ND](http://creativecommons.org/licenses/by-nd/3.0/) license.
 
 == Changelog ==
+
+= 0.8.3 =
+* Updates for compatibility with Wordpress 6.8.3
+* Modifications to address security vulnerability per CVE-2021-39336
 
 = 0.7.25 =
 * FIXED Cross-Site Scripting exploit (XSS)

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Job Manager ===
-Contributors: SMB-dev, gobblelogic
+Contributors: SMB-dev, gobblelogic, jmdevnet
 Donate link: http://www.wp-jobmanager.com/donate/
 Plugin URI: http://www.wp-jobmanager.com
 License: GPLv3

--- a/setup.php
+++ b/setup.php
@@ -32,6 +32,9 @@ function jobman_new_blog( $blog_id, $user_id, $domain, $path, $site_id, $meta ) 
 }
 
 function _jobman_activate() {
+	
+	global $jobman_shortcodes;   //jm
+
 	$options = get_option( 'jobman_options' );
 	if( is_array( $options ) ) {
 		$version = $options['version'];

--- a/setup.php
+++ b/setup.php
@@ -121,6 +121,7 @@ function jobman_create_default_settings() {
 								),
 					'user_registration' => 0,
 					'user_registration_required' => 0,
+					'recaptcha_key' => ''
 				);
 
 	$titletext = __( 'Title', 'jobman' );

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -1,0 +1,113 @@
+<?php
+// Adding support for shortcodes in normal pages and posts JM 10/26/21
+
+add_shortcode( 'jobmansn_list_jobs', 'jobmansn_list_jobs');
+add_shortcode( 'jobmansn_debug', 'jobmansn_debug');
+
+function jobmansn_list_jobs(){
+	global $wp_filter, $wp_current_filter, $wp_query, $wpdb;
+	$options = get_option( 'jobman_options' );
+	//var_dump ($options);
+	$fields = $options['job_fields'];													// Job fields to iterate over for each job
+	//var_dump ($fields);
+	$content = '';
+	
+	// Get the list of jobs to dipslay.
+	$args = array('post_type' => 'jobman_job', 'suppress_filters' => FALSE );		// Query arguments
+	$args['numberposts'] = -1;
+	
+	add_filter('posts_where', 'jobman_job_live_where', 10, 1);
+	add_filter('posts_join', 'jobman_job_live_join', 10, 1);
+	add_filter('posts_distinct', 'jobman_job_live_distinct', 10, 1);							// Grab list of jobs
+	
+	$get_jobs = new WP_Query;
+	$jobs = $get_jobs->query($args);	
+	//var_dump($get_jobs->request);
+	
+	remove_filter('posts_where', 'jobman_job_live_where', 10, 1);
+	remove_filter('posts_join', 'jobman_job_live_join', 10, 1);
+	remove_filter('posts_distinct', 'jobman_job_live_distinct', 10, 1);
+	
+	// Display the job list, or a nice message.
+	$content .= '<h1>Current Openings</h1>';
+	if ( count ($jobs) > 0){
+		foreach ($jobs as $job){
+			$content .= jobmansn_job_entry( $job, $fields );
+		}
+	} else {
+		$content .= '<p>We don\'t currently have any jobs available.  Please check back regularly, ';
+		$content .= 'as we frequently post new jobs.  In the meantime, you can also <a href="';
+		$content .= jobmansn_get_app_url() . '">send through your resume</a>, which we\'ll keep on file.</p>';
+	}
+	
+	return $content;
+	
+}
+
+// Takes a job post entry and returns the div to be displayed in the job list
+function jobmansn_job_entry( $job, $fields ){
+	//var_dump ($job);
+	$jobdata = get_post_meta( $job->ID );												// Get job metadata
+	//var_dump ($jobdata);
+	$desired_fields = ['Salary', 'Start Date', 'Location'];
+	$content = '<div><table class="job-table">';										// Job title
+	$content .= '<tr><th scope="row">Title</th>';
+	$content .= '<td><a href = "' . get_page_link($job) . '">';
+	$content .= $job->post_title . '</a></td></tr>';
+	foreach ($fields as $fid => $field){												// Fields
+		$fielddata = $jobdata['data' . $fid][0];
+		if (in_array($field['label'], $desired_fields) && $fielddata != ''){			// If it's one of the ones we want to show on the list, and not empty
+			$content .= '<tr><th scope="row">' . $field['label'];
+			$content .= '<td>' . $fielddata;
+			$content .= '</td>';
+			$content .= '</th></tr>';
+		}
+	}
+	$content .= '<tr><td></td>';
+	$content .= '<td class="jobs-applynow"><a href="' . jobmansn_apply_url($job) . '">';
+	$content .= 'Apply Now</a></td></tr>';												// Apply now
+	$content .= '</table><br><br></div>';
+	return $content;
+}
+
+
+// Take a job post entry and returns the URL for the application page
+function jobmansn_apply_url( $job ){
+	$url = jobmansn_get_app_url() . $job->ID . '/';
+	return $url;
+}
+
+// Retrun application form URL
+function jobmansn_get_app_url(){
+	$args['post_type'] = 'jobman_app_form';
+	$args['numberposts'] = 1;															// There should be only one, but make sure
+	$appform = get_posts( $args )[0];
+	$url = get_page_link($appform);
+	return $url;
+}
+
+// Return debug info to the [jobmansn_debug] shortcode
+function jobmansn_debug(){
+	global $wp_rewrite;
+	$content = '';
+	$options = get_option( 'jobman_options' );
+	
+	$content .= '<h3>Job Manager Options Dump</h3>';
+	foreach ($options as $key => $value){
+		$content .= '<p><b>' . var_export($key, TRUE) . '</b>    ' . var_export($value, TRUE) . '</p>';
+	}
+	
+	foreach ($options['rewrite_rules'] as $key => $rule){
+		$content .= '<h3>Job Manager Rewrite Rule:</h3>';
+		$content .= '<p><b>' . var_export($key, TRUE) . '</b>    ' . var_export($rule, TRUE) . '</p>';
+	}
+		
+	foreach ($wp_rewrite->rules as $key => $rule){
+		$content .= '<h3>Site Rewrite Rule:</h3>';
+		$content .= '<p><b>' . var_export($key, TRUE) . '</b>    ' . var_export($rule, TRUE) . '</p>';
+	}
+	return $content;
+}
+
+
+?>

--- a/widgets.php
+++ b/widgets.php
@@ -1,11 +1,11 @@
 <?php
 class JobmanLatestJobsWidget extends WP_Widget {
     /** constructor */
-    function JobmanLatestJobsWidget() {
+    function __construct() {
 		$name = __( 'Job Manager: Recent Jobs', 'jobman');
 		$options = array( 'description' => __( 'A list of the most recent jobs posted to your site', 'jobman' ) );
 		
-        parent::WP_Widget( false, $name, $options );	
+        parent::__construct( false, $name, $options );	
     }
 
     function widget( $args, $instance ) {		
@@ -160,11 +160,11 @@ class JobmanLatestJobsWidget extends WP_Widget {
 
 class JobmanCategoriesWidget extends WP_Widget {
     /** constructor */
-    function JobmanCategoriesWidget() {
+    function __construct() {
 		$name = __( 'Job Manager: Categories', 'jobman');
 		$options = array( 'description' => __( 'A list or dropdown of Job Manager categories', 'jobman' ) );
 		
-        parent::WP_Widget( false, $name, $options );	
+        parent::__construct( false, $name, $options );	
     }
 
     function widget( $args, $instance ) {
@@ -307,11 +307,11 @@ class JobmanCategoriesWidget extends WP_Widget {
 
 class JobmanHighlightedJobsWidget extends WP_Widget {
     /** constructor */
-    function JobmanHighlightedJobsWidget() {
+    function __construct() {
 		$name = __( 'Job Manager: Highlighted Jobs', 'jobman');
 		$options = array( 'description' => __( 'A list jobs that have been marked as highlighted', 'jobman' ) );
 		
-        parent::WP_Widget( false, $name, $options );	
+        parent::__construct( false, $name, $options );	
     }
 
     function widget( $args, $instance ) {
@@ -394,11 +394,11 @@ class JobmanHighlightedJobsWidget extends WP_Widget {
 
 class JobmanJobsWidget extends WP_Widget {
     /** constructor */
-    function JobmanJobsWidget() {
+    function __construct() {
 		$name = __( 'Job Manager: Selected Jobs', 'jobman');
 		$options = array( 'description' => __( 'A customizable list jobs posted to your site', 'jobman' ) );
 		
-        parent::WP_Widget( false, $name, $options );	
+        parent::__construct( false, $name, $options );	
     }
 
     function widget( $args, $instance ) {		


### PR DESCRIPTION
I've made a hand full of modifications to achieve compatibility with WP 6.8.3 and PHP 8.

I also refactored handling of posts from the admin job edit form, and added entry sanitation logic which should eliminate the vulnerability documented in CVE-2021-39336.  My hope is that this update might be able to get the plugin re-enabled in the Wordpress plugin repository.  Ref Issue #6.

Thanks